### PR TITLE
ddev: update to 1.24.4

### DIFF
--- a/audio/libsidplayfp/Portfile
+++ b/audio/libsidplayfp/Portfile
@@ -21,4 +21,6 @@ checksums           rmd160  53a4b4c0dae436e0a1b327fd3fdb921c1a8d2176 \
                     sha256  1c09e3182dd53fc9ee37800f194f0d68e1fe06a8b5aee9abb5ab35d7bf6274b7 \
                     size    842564
 
+depends_lib         port:libgcrypt
+
 compiler.cxx_standard   2011

--- a/audio/sidplayfp/Portfile
+++ b/audio/sidplayfp/Portfile
@@ -23,6 +23,8 @@ checksums           rmd160  48238e9ef1517d954290122c822ab1c15481fa19 \
 depends_build       path:bin/pkg-config:pkgconfig
 
 depends_lib         port:libsidplayfp \
-                    port:mpg123
+                    port:mpg123 \
+                    port:libiconv \
+                    port:pulseaudio
 
 compiler.cxx_standard   2011

--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,12 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.24.3 v
+go.setup            github.com/ddev/ddev 1.24.4 v
 go.offline_build    no
 
-checksums           rmd160  9f4e1e735149b2b4a0ba171a7e76eee8fecc4356 \
-                    sha256  222ba16d6465f947ac2f39268f0f937379e960e9e4f6fe1604380e0f7c87693c \
-                    size    19253633
+checksums           rmd160  2575cb97d8484b0fd125ae5695b60473ba1c16dd \
+                    sha256  728b97d1bd82f29b2941efe5ee79810a7d31dcd0ed9de3e5c225f9622119e6e5 \
+                    size    19466914
 
 categories          devel
 license             Apache-2

--- a/devel/ddev/Portfile
+++ b/devel/ddev/Portfile
@@ -3,9 +3,12 @@
 PortSystem          1.0
 PortGroup           golang 1.0
 
-go.setup            github.com/ddev/ddev 1.24.1 v
+go.setup            github.com/ddev/ddev 1.24.3 v
 go.offline_build    no
-fetch.type          git
+
+checksums           rmd160  9f4e1e735149b2b4a0ba171a7e76eee8fecc4356 \
+                    sha256  222ba16d6465f947ac2f39268f0f937379e960e9e4f6fe1604380e0f7c87693c \
+                    size    19253633
 
 categories          devel
 license             Apache-2

--- a/devel/gperf/Portfile
+++ b/devel/gperf/Portfile
@@ -4,11 +4,12 @@ PortSystem 1.0
 PortGroup  clang_dependency 1.0
 
 name            gperf
-version         3.1
+version         3.2
+revision        0
 categories      devel
-platforms       darwin
 license         GPL-3+
-maintainers     {mcalhoun @MarcusCalhoun-Lopez} openmaintainer
+maintainers     {mcalhoun @MarcusCalhoun-Lopez} \
+                {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer
 
 description     GNU perfect hash generator
 long_description \
@@ -17,9 +18,9 @@ long_description \
 homepage        https://www.gnu.org/software/gperf/gperf.html
 master_sites    gnu
 
-checksums       md5     9e251c0a618ad0824b51117d5d9db87e \
-                sha1    e3c0618c2d2e5586eda9498c867d5e4858a3b0e2 \
-                rmd160  0bccbfd60ef68a93b407d9ce157748475775e74b
+checksums       rmd160  c6b492ee7098e59099677934c113b43e32063915 \
+                sha256  e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62 \
+                size    1268603
 
 installs_libs   no
 

--- a/devel/gperf/Portfile
+++ b/devel/gperf/Portfile
@@ -1,35 +1,35 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
-PortSystem 1.0
-PortGroup  clang_dependency 1.0
+PortSystem          1.0
+PortGroup           clang_dependency 1.0
 
-name            gperf
-version         3.2
-revision        0
-categories      devel
-license         GPL-3+
-maintainers     {mcalhoun @MarcusCalhoun-Lopez} \
-                {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer
+name                gperf
+version             3.2
+revision            0
 
-description     GNU perfect hash generator
-long_description \
-    Generates a perfect hash function for various input.
+categories          devel
+license             GPL-3+
+maintainers         {mcalhoun @MarcusCalhoun-Lopez} \
+                    {@aeiouaeiouaeiouaeiouaeiouaeiou outlook.com:aeioudev} openmaintainer
 
-homepage        https://www.gnu.org/software/gperf/gperf.html
-master_sites    gnu
+description         GNU perfect hash generator
+long_description    Generates a perfect hash function for various input.
 
-checksums       rmd160  c6b492ee7098e59099677934c113b43e32063915 \
-                sha256  e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62 \
-                size    1268603
+homepage            https://www.gnu.org/software/gperf/gperf.html
+master_sites        gnu
 
-installs_libs   no
+checksums           rmd160  c6b492ee7098e59099677934c113b43e32063915 \
+                    sha256  e0ddadebb396906a3e3e4cac2f697c8d6ab92dffa5d365a5bc23c7d41d30ef62 \
+                    size    1268603
 
-configure.args  --infodir=${prefix}/share/info
+installs_libs       no
+
+configure.args      --infodir=${prefix}/share/info
 
 # Also needed by later clangs.
 if {${os.platform} eq "darwin" && ${os.major} < 11 && ${cxx_stdlib} eq "libc++"} {
     clang_dependency.extra_versions 3.7
 }
 
-test.run        yes
-test.target     check
+test.run            yes
+test.target         check

--- a/devel/libffi/Portfile
+++ b/devel/libffi/Portfile
@@ -4,12 +4,12 @@ PortSystem          1.0
 PortGroup           muniversal 1.0
 PortGroup           github 1.0
 
-github.setup        libffi libffi 3.4.6 v
-revision            2
+github.setup        libffi libffi 3.4.8 v
+revision            0
 
-checksums           rmd160  8e927f6bc340564414a87cc5b6dffc9ce53eefd8 \
-                    sha256  b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e \
-                    size    1391684
+checksums           rmd160  ea8558bf3afdf92f470859807a31c6dc78921d0e \
+                    sha256  bc9842a18898bfacb0ed1252c4febcc7e78fa139fd27fdc7a3e30d9d9356119b \
+                    size    1397992
 
 github.tarball_from releases
 categories          devel
@@ -31,11 +31,7 @@ homepage            https://www.sourceware.org/libffi/
 
 # patch-sources.diff: fixes for various issues.
 #
-# This includes one upstream fix for a build problem on Sequoia.  Although
-# v3.4.7 includes this fix, it also has more test failures than v3.4.6,
-# so for now we just cherry-pick the needed change.
-#
-# This diff is from v3.4.6 vs. macports-3.4.6r2.
+# This diff is from v3.4.8 vs. macports-3.4.8.
 #
 patchfiles          patch-sources.diff
 
@@ -64,8 +60,6 @@ platform darwin {
 # compiler's default architecture.  We need to force this to match the
 # target architecture to get the correct build.  Merely providing the
 # correct architecture options in xxFLAGS is insufficient.
-#
-# This is a more general fix than the former fix for 10.6/ppc/Rosetta
 #
 if { [variant_isset universal] } {
     merger_arch_compiler yes

--- a/devel/libffi/files/patch-sources.diff
+++ b/devel/libffi/files/patch-sources.diff
@@ -1,37 +1,5 @@
---- src/aarch64/sysv.S.orig	2024-02-15 04:54:35.000000000 -0800
-+++ src/aarch64/sysv.S	2025-04-06 16:16:17.000000000 -0700
-@@ -89,8 +89,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN
-    x5 closure
- */
- 
--	cfi_startproc
- CNAME(ffi_call_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	/* Sign the lr with x1 since that is where it will be stored */
- 	SIGN_LR_WITH_REG(x1)
-@@ -347,8 +347,8 @@ CNAME(ffi_closure_SYSV_V):
- #endif
- 
- 	.align	4
--	cfi_startproc
- CNAME(ffi_closure_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	SIGN_LR
- 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
-@@ -643,8 +643,8 @@ CNAME(ffi_go_closure_SYSV_V):
- #endif
- 
- 	.align	4
--	cfi_startproc
- CNAME(ffi_go_closure_SYSV):
-+	cfi_startproc
- 	BTI_C
- 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
- 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
---- src/powerpc/darwin.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin.S	2025-04-06 16:16:17.000000000 -0700
+--- src/powerpc/darwin.S.orig	2024-06-01 10:42:02.000000000 -0700
++++ src/powerpc/darwin.S	2025-04-17 11:40:54.000000000 -0700
 @@ -31,8 +31,6 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -41,8 +9,8 @@
  ; Define some pseudo-opcodes for size-independent load & store of GPRs ...
  #define lgu		MODE_CHOICE(lwzu, ldu)
  #define lg		MODE_CHOICE(lwz,ld)
---- src/powerpc/darwin_closure.S.orig	2023-03-15 07:19:45.000000000 -0700
-+++ src/powerpc/darwin_closure.S	2025-04-06 16:16:17.000000000 -0700
+--- src/powerpc/darwin_closure.S.orig	2024-06-01 10:42:02.000000000 -0700
++++ src/powerpc/darwin_closure.S	2025-04-17 11:40:54.000000000 -0700
 @@ -34,7 +34,7 @@
  #define MODE_CHOICE(x, y) x
  #endif
@@ -52,8 +20,8 @@
  
  ; Define some pseudo-opcodes for size-independent load & store of GPRs ...
  #define lgu		MODE_CHOICE(lwzu, ldu)
---- testsuite/lib/libffi.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/lib/libffi.exp	2025-04-06 16:16:17.000000000 -0700
+--- testsuite/lib/libffi.exp.orig	2024-06-01 10:42:02.000000000 -0700
++++ testsuite/lib/libffi.exp	2025-04-17 11:40:54.000000000 -0700
 @@ -516,7 +516,10 @@ proc run-many-tests { testcases extra_fl
          }
        }
@@ -66,8 +34,8 @@
          if [info exists env(LIBFFI_TEST_OPTIMIZATION)] {
  	  set optimizations [ list $env(LIBFFI_TEST_OPTIMIZATION) ]
          } else {
---- testsuite/libffi.bhaible/bhaible.exp.orig	2023-03-15 07:19:45.000000000 -0700
-+++ testsuite/libffi.bhaible/bhaible.exp	2025-04-06 16:16:17.000000000 -0700
+--- testsuite/libffi.bhaible/bhaible.exp.orig	2024-06-01 10:42:02.000000000 -0700
++++ testsuite/libffi.bhaible/bhaible.exp	2025-04-17 11:40:54.000000000 -0700
 @@ -24,7 +24,10 @@ global compiler_vendor
  # was done in a pretty lazy fashion, and requires the use of compiler
  # flags to disable warnings for now.

--- a/devel/libgpg-error/Portfile
+++ b/devel/libgpg-error/Portfile
@@ -15,7 +15,7 @@ if {${os.platform} eq "darwin" && ${os.major} < 18} {
 }
 
 name            libgpg-error
-version         1.53
+version         1.54
 revision        0
 categories      devel
 license         LGPL-2.1+
@@ -33,9 +33,9 @@ master_sites    gnupg
 
 use_bzip2       yes
 
-checksums       rmd160  1183ae1a87aab3e270262fa628fefa306af4e5a6 \
-                sha256  6a0721b52027415f53abcbf63b5c37776a0f774d9126d560a3ce76c0eb42903f \
-                size    1106986
+checksums       rmd160  8290e56625cdc7eba82da1564272ff98cbc15ce7 \
+                sha256  607dcadfd722120188eca5cd07193158b9dd906b578a557817ec779bd5e16d0e \
+                size    1108176
 
 depends_build   port:gettext
 

--- a/devel/sccs/Portfile
+++ b/devel/sccs/Portfile
@@ -5,8 +5,6 @@ PortSystem          1.0
 name                sccs
 version             5.09
 categories          devel
-platforms           darwin
-supported_archs     i386 x86_64
 license             CDDL
 maintainers         {makr @mohd-akram} openmaintainer
 
@@ -16,7 +14,7 @@ description         SCCS version control system
 
 long_description    The UNIX Source Code Control System
 
-homepage            http://sccs.sourceforge.net
+homepage            https://sccs.sourceforge.net
 
 master_sites        sourceforge
 use_bzip2           yes
@@ -25,11 +23,14 @@ checksums           rmd160  707f0bac8377dfb1df0fd22727c3cb3b7df1f489 \
                     sha256  331bf09d1fb2ca01739e5f97cc46c6ef134661535f2ce541f90b5b9548be431b \
                     size    1114069
 
-patchfiles          patch-bdiff.diff patch-delta.diff patch-diff.diff \
+patchfiles          patch-rules-mklinks.diff \
+                    patch-bdiff.diff patch-delta.diff patch-diff.diff \
                     patch-help.diff patch-sccs.diff
 
 configure.cmd       env | grep -E '^(CC?|CPP|CXX|LD)(FLAGS)?='
 configure.pre_args  >> DEFAULTS/Defaults
+
+configure.cflags-append -std=c89
 
 build.args          INS_BASE=${prefix} INS_RBASE=${prefix} SCCS_BIN_PRE= \
                     SCCS_HELP_PRE=share/${name}/ GMAKE_NOWARN=true

--- a/devel/sccs/Portfile
+++ b/devel/sccs/Portfile
@@ -1,6 +1,7 @@
 # -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:ft=tcl:et:sw=4:ts=4:sts=4
 
 PortSystem          1.0
+PortGroup           makefile 1.0
 
 name                sccs
 version             5.09
@@ -27,16 +28,14 @@ patchfiles          patch-rules-mklinks.diff \
                     patch-bdiff.diff patch-delta.diff patch-diff.diff \
                     patch-help.diff patch-sccs.diff
 
-configure.cmd       env | grep -E '^(CC?|CPP|CXX|LD)(FLAGS)?='
-configure.pre_args  >> DEFAULTS/Defaults
-
 configure.cflags-append -std=c89
+makefile.override   CFLAGS
 
 build.args          INS_BASE=${prefix} INS_RBASE=${prefix} SCCS_BIN_PRE= \
-                    SCCS_HELP_PRE=share/${name}/ GMAKE_NOWARN=true
+                    SCCS_HELP_PRE=share/${name}/ GMAKE_NOWARN=true \
+                    LDOPTX="${configure.ldflags}"
 
-destroot.args       INS_BASE=${prefix} INS_RBASE=${prefix} SCCS_BIN_PRE= \
-                    SCCS_HELP_PRE=share/${name}/ GMAKE_NOWARN=true
+destroot.args       {*}${build.args}
 
 post-destroot {
     delete ${destroot}${prefix}/ccs/bin/sccspatch

--- a/devel/sccs/files/patch-rules-mklinks.diff
+++ b/devel/sccs/files/patch-rules-mklinks.diff
@@ -1,0 +1,12 @@
+--- RULES/MKLINKS.orig	2018-11-15 03:19:51
++++ RULES/MKLINKS	2025-04-17 21:01:04
+@@ -393,6 +393,9 @@
+ $symlink	i386-darwin-clang.rul	x86_64-darwin-clang.rul
+ $symlink	i386-darwin-clang32.rul	x86_64-darwin-clang32.rul
+ $symlink	i386-darwin-clang64.rul	x86_64-darwin-clang64.rul
++$symlink	i386-darwin-clang.rul	arm64-darwin-clang.rul
++$symlink	i386-darwin-clang32.rul	arm64-darwin-clang32.rul
++$symlink	i386-darwin-clang64.rul	arm64-darwin-clang64.rul
+ $symlink	i86pc-sunos5-cc.rul	i86pc-sunos5-cc32.rul
+ $symlink	i86pc-sunos5-cc.rul	i86pc-sunos5-cc64.rul
+ $symlink	i86pc-sunos5-clang.rul	i86pc-sunos5-clang32.rul

--- a/devel/swig/Portfile
+++ b/devel/swig/Portfile
@@ -56,7 +56,6 @@ configure.args-append --without-javascript
 
 array set bindings {
     csharp      {port:mono              csharp}
-    gcj         {port:gcc47             "gcj=${prefix}/bin/gcj-mp-4.7 --with-gcjh=${prefix}/bin/gcjh-mp-4.7"}
     d           {port:phobos            d}
     go          {port:go                go}
     guile       {port:guile-2.2         "guile=${prefix}/bin/guile-2.2 --with-guile-config=${prefix}/bin/guile-config-2.2"}
@@ -72,7 +71,7 @@ array set bindings {
     tcl         {port:tcl               tcl}
 }
 array set prettynames {csharp "C#"
-    d D gcj GCJ go Go guile Guile java Java lua Lua
+    d D go Go guile Guile java Java lua Lua
     ocaml "Objective Caml" octave Octave perl5 Perl php "PHP 8"
     python Python r R ruby Ruby tcl Tcl}
 
@@ -131,51 +130,6 @@ subport swig-php {
     }
     if {![info exists any_php_variant_set]} {
         ui_error "\n\nA +phpXY variant must be selected; the variant '-php${php_default_ver}' cannot be used alone.\n"
-        return -code error "Invalid variant selection"
-    }
-}
-
-subport swig-gcj {
-    variant gcc43 conflicts gcc44 gcc45 gcc47 gcc48 description {build using GCJ 4.3} {
-        depends_lib-delete port:gcc47
-        depends_lib-append port:gcc43
-        configure.args-delete --with-gcj=${prefix}/bin/gcj-mp-4.7 --with-gcjh=${prefix}/bin/gcjh-mp-4.7
-        configure.args-append --with-gcj=${prefix}/bin/gcj-mp-4.3 --with-gcjh=${prefix}/bin/gcjh-mp-4.3
-    }
-
-    variant gcc44 conflicts gcc43 gcc45 gcc47 gcc48 description {build using GCJ 4.4} {
-        depends_lib-delete port:gcc47
-        depends_lib-append port:gcc44
-        configure.args-delete --with-gcj=${prefix}/bin/gcj-mp-4.7 --with-gcjh=${prefix}/bin/gcjh-mp-4.7
-        configure.args-append --with-gcj=${prefix}/bin/gcj-mp-4.4 --with-gcjh=${prefix}/bin/gcjh-mp-4.4
-    }
-
-    variant gcc45 conflicts gcc43 gcc44 gcc47 gcc48 description {build using GCJ 4.5} {
-        depends_lib-delete port:gcc47
-        depends_lib-append port:gcc45
-        configure.args-delete --with-gcj=${prefix}/bin/gcj-mp-4.7 --with-gcjh=${prefix}/bin/gcjh-mp-4.7
-        configure.args-append --with-gcj=${prefix}/bin/gcj-mp-4.5 --with-gcjh=${prefix}/bin/gcjh-mp-4.5
-    }
-
-    # No +gcc46 because the gcc46 port does not build GCJ.
-
-    variant gcc48 conflicts gcc43 gcc44 gcc45 gcc47 description {build using GCJ 4.8} {
-        depends_lib-delete port:gcc47
-        depends_lib-append port:gcc48
-        configure.args-delete --with-gcj=${prefix}/bin/gcj-mp-4.7 --with-gcjh=${prefix}/bin/gcjh-mp-4.7
-        configure.args-append --with-gcj=${prefix}/bin/gcj-mp-4.8 --with-gcjh=${prefix}/bin/gcjh-mp-4.8
-    }
-
-    # Placeholder variant for the default.
-    variant gcc47 conflicts gcc43 gcc44 gcc45 gcc48 description {build using GCJ 4.7} {}
-
-    if {![variant_isset gcc43] && ![variant_isset gcc44] && ![variant_isset gcc45] &&
-        ![variant_isset gcc47] && ![variant_isset gcc48]} {
-        default_variants +gcc47
-    }
-    if {![variant_isset gcc43] && ![variant_isset gcc44] && ![variant_isset gcc45] &&
-        ![variant_isset gcc47] && ![variant_isset gcc48]} {
-        ui_error "\n\nA +gcc4X variant must be selected; the variant '-gcc47' cannot be used alone.\n"
         return -code error "Invalid variant selection"
     }
 }

--- a/gis/gdal/Portfile
+++ b/gis/gdal/Portfile
@@ -8,12 +8,12 @@ PortGroup           legacysupport 1.1
 PortGroup           muniversal 1.0
 
 name                gdal
-version             3.10.2
-revision            3
+version             3.10.3
+revision            0
 
-checksums           rmd160  35e3e3a75959d0ab949f4e68dcb39b947508046d \
-                    sha256  67b4e08acd1cc4b6bd67b97d580be5a8118b586ad6a426b09d5853898deeada5 \
-                    size    9206880
+checksums           rmd160  2bbada1e85cd149e291d1782981afe222eec2533 \
+                    sha256  335a8d2c7567d783563d3fed37e8b58d72d9c1723f6fd1d8c299fe4c0d936781 \
+                    size    9208456
 
 categories          gis
 license             MIT BSD

--- a/java/openjdk17-temurin/Portfile
+++ b/java/openjdk17-temurin/Portfile
@@ -20,8 +20,8 @@ universal_variant no
 # https://adoptium.net/temurin/releases/
 supported_archs  x86_64 arm64
 
-version      ${feature}.0.14
-set build    7
+version      ${feature}.0.15
+set build    6
 revision     0
 
 description  Eclipse Temurin, based on OpenJDK ${feature} (Long Term Support until at least October 2027)
@@ -31,14 +31,14 @@ master_sites https://github.com/adoptium/temurin${feature}-binaries/releases/dow
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     OpenJDK${feature}U-jdk_x64_mac_hotspot_${version}_${build}
-    checksums    rmd160  e81ef2563735e9f3f25047c3e9330786773058b5 \
-                 sha256  bc2e9225d156d27149fc7a91817e6b64f76132b2b81d1f44cb8c90d7497b6ea7 \
-                 size    180020160
+    checksums    rmd160  e9a4146224ef7eeb9815b5017127e3fa4fc046f9 \
+                 sha256  424d7f758a272718887bd93f4d8b63e560c0797a884e036c4b3dbf5d2cdfa1cd \
+                 size    180100463
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     OpenJDK${feature}U-jdk_aarch64_mac_hotspot_${version}_${build}
-    checksums    rmd160  2929341696d7b815065ebc7b7af80bdfba3e5d0d \
-                 sha256  95bcc8052340394b87644d71a60fb26f31857f4090a7dfee57113e9e0f2dfacb \
-                 size    185303401
+    checksums    rmd160  982511fb8529d9e8d11f5711c2feeb7edb2befc2 \
+                 sha256  1a2fa2bb9ea059cf2c1ab3e296a98e006fb6fdad2bd19ce52df48794eaa1836a \
+                 size    185382473
 }
 
 worksrcdir   jdk-${version}+${build}

--- a/java/openjdk17/Portfile
+++ b/java/openjdk17/Portfile
@@ -25,12 +25,19 @@ checksums           rmd160  815a4bf32aa6f4113f71eff5ae976ab871ed385a \
                     sha256  0ead550ff5abe15df9c2c8b3656198e6e6679186b544e1fa329436e90eb46b31 \
                     size    66554460
 
+set port_jdk_build  openjdk${feature}-zulu
+
 depends_lib         port:freetype \
                     port:libiconv
-depends_build       port:openjdk${feature}-zulu \
+depends_build       port:${port_jdk_build} \
                     port:autoconf \
                     port:gmake \
                     port:bash
+
+# Don't block binary distribution, due to build JDK
+# See: https://trac.macports.org/ticket/72359
+license_noconflict-append \
+                    ${port_jdk_build}
 
 pre-patch {
     reinplace "s|libffi.so.?|libffi.?.dylib|g" ${worksrcpath}/make/autoconf/lib-ffi.m4

--- a/lang/crystal/Portfile
+++ b/lang/crystal/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        crystal-lang crystal 1.16.1
 github.tarball_from archive
@@ -70,9 +71,6 @@ post-patch {
 
 configure.ldflags-append    -Wl,-rpath,${prefix}/libexec/llvm-${llvm_version}/lib
 
-configure.cmd       env | grep -E '^(CC?|CPP|CXX|LD)(FLAGS)?='
-configure.pre_args  > Makefile.local
-
 set llvm_config     LLVM_CONFIG=llvm-config-mp-${llvm_version}
 
 compiler.cxx_standard  2014
@@ -88,7 +86,7 @@ post-build {
 }
 
 destroot.target-append  install_docs
-destroot.args       -o docs PREFIX=${prefix}
+destroot.args       -o docs
 destroot.env        ${llvm_config}
 
 test.run            yes

--- a/lang/dart-sdk/Portfile
+++ b/lang/dart-sdk/Portfile
@@ -3,7 +3,7 @@
 PortSystem          1.0
 
 name                dart-sdk
-version             3.7.2
+version             3.7.3
 categories          lang
 license             BSD
 maintainers         {amake @amake} openmaintainer
@@ -25,14 +25,14 @@ worksrcdir          ${name}
 
 if {${configure.build_arch} eq "x86_64"} {
     distname     dartsdk-macos-x64-release
-    checksums    rmd160  41621336841802068879c578324bf8cbee31e706 \
-                 sha256  060886d2b8ae832f89ce7db971eeb6218a507e37071152487dd52eb256a449ae \
-                 size    216484427
+    checksums    rmd160  00fb16417eb955cc5fe82b556a76115c958716de \
+                 sha256  98a83e7f279f13c0589403cc11cbd4b75b9fbad89ddb5c2bae7a259b63bbe809 \
+                 size    216488231
 } elseif {${configure.build_arch} eq "arm64"} {
     distname     dartsdk-macos-arm64-release
-    checksums    rmd160  dbb81164fce9394317469c1d777b42695c803f51 \
-                 sha256  106e63d9590090993a95ee51e68729de2d09ca2b7b7bd16c0b5fb57a60b3657c \
-                 size    214714946
+    checksums    rmd160  d4f11c4995c1104856ccc131823bd160cf15fd93 \
+                 sha256  eb6479d1880185b351d7fc1382a460417b140a9dd6437a67a969ef69d3fa648c \
+                 size    214718411
 }
 
 use_configure       no

--- a/lang/py-htmldocs/Portfile
+++ b/lang/py-htmldocs/Portfile
@@ -13,10 +13,10 @@ license             PSF
 if {$subport != $name} {
     if {${python.version} == 27} { version 2.7.18 }
     if {${python.version} == 37} { version 3.7.17 }
-    if {${python.version} == 310} { version 3.10.16 }
-    if {${python.version} == 311} { version 3.11.11 }
-    if {${python.version} == 312} { version 3.12.9 }
-    if {${python.version} == 313} { version 3.13.2 }
+    if {${python.version} == 310} { version 3.10.17 }
+    if {${python.version} == 311} { version 3.11.12 }
+    if {${python.version} == 312} { version 3.12.10 }
+    if {${python.version} == 313} { version 3.13.3 }
 }
 
 categories          lang
@@ -62,27 +62,27 @@ if {${name} != ${subport}} {
     }
 
     if {${python.version} == 310} {
-        checksums   rmd160  db838efee82159693f71551918e4f41d0bb9f95c \
-                    sha256  95c3749e9750b7148724c577adbd6b3c75b4ae1dd9e5604bd2968554f9a91251 \
-                    size    7425105
+        checksums   rmd160  184f2cb07c66bea074f216ca89a93bc6eaa226a7 \
+                    sha256  34a0453ddb426be856f1c5fcda37ac01068fea3af79f5b26ba209f5832c0a849 \
+                    size    7459592
     }
 
     if {${python.version} == 311} {
-        checksums   rmd160  bc1d47ffd70b0dbf5a337fdb5f1b7051e844d34e \
-                    sha256  eb1991158d4b80560bda2a3672f699ced40dfb9ec7f6d931c24d8c40ffd0b761 \
-                    size    7983082
+        checksums   rmd160  a1f12af5edaf72ae7377739553071a5d617ec096 \
+                    sha256  43eb8c160873d3f0d4966962862273496f62409ab02b3a3a3f563f930066325b \
+                    size    7994774
     }
 
     if {${python.version} == 312} {
-        checksums   rmd160  121ddaf774a5c6f18716ad493b41fdfe97ba5565 \
-                    sha256  a284b6189090fd87ffb232911eed73510fc9cfcd7afe41a8eefd0e653fd8dcbb \
-                    size    8428229
+        checksums   rmd160  a8ad18cf39c691f90e1953563f6eaffa42a50d80 \
+                    sha256  16347781a36c25042c3b0472cdc25a952ee3ecf1953c8448a854dc83763ebbb0 \
+                    size    8428154
     }
 
     if {${python.version} == 313} {
-        checksums   rmd160  c986be9f1d6f2b63ef8729f41c80f88c0fce38e9 \
-                    sha256  5ebc924fd53716292199f7e39bf53a1066f6673c22d9c0a2d3ca27096fefd1ae \
-                    size    10344279
+        checksums   rmd160  d5dc114887997f60e4eb33c8fc8f0b9a2377ca2a \
+                    sha256  8ad1af833fc455d09837ab85a83e84502c7f6e7be34d31295330b4f640897cbe \
+                    size    10354611
     }
 
     dist_subdir         ${name}/${revision}

--- a/octave/octave-datatypes/Portfile
+++ b/octave/octave-datatypes/Portfile
@@ -1,0 +1,15 @@
+# -*- coding: utf-8; mode: tcl; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*- vim:fenc=utf-8:et:sw=4:ts=4:sts=4
+
+PortSystem          1.0
+PortGroup           octave 1.0
+
+octave.setup        github pr0m1th3as datatypes 1.0.2 release-
+revision            0
+license             GPL-3+
+maintainers         {mps @Schamschula} openmaintainer
+description         Extra data types for GNU Octave
+long_description    {*}${description}
+
+checksums           rmd160  7cf7af773c15d157474b66b333199ba0f15c89e9 \
+                    sha256  0cbf9171e366d2cfd067ed8089a97c3320b3475a88f63680c3ceeaaca55976f3 \
+                    size    288518

--- a/perl/p5-business-isbn-data/Portfile
+++ b/perl/p5-business-isbn-data/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           perl5 1.0
 
 perl5.branches      5.28 5.30 5.32 5.34
-perl5.setup         Business-ISBN-Data 20250411.001 ../../authors/id/B/BR/BRIANDFOY
+perl5.setup         Business-ISBN-Data 20250416.001 ../../authors/id/B/BR/BRIANDFOY
 revision            0
 license             Artistic-2
 maintainers         nomaintainer
@@ -14,9 +14,9 @@ long_description    {*}${description}
 platforms           {darwin any}
 supported_archs     noarch
 
-checksums           rmd160  e99c7bdb5f3cf1b341e4a5f9fa2afe1b69f7d74b \
-                    sha256  36ab645538985cee24dc17aa52004b84b2a05f71fb8ac9adb7faa4d617220e78 \
-                    size    36719
+checksums           rmd160  a0af32c369522a375a43dc51e8a4916debf7b358 \
+                    sha256  e509ceab9a75375a873e0feb7428b49636b81bb69354e5f6ff8843b9dbca33ce \
+                    size    36775
 
 livecheck.type      regex
 livecheck.url       https://cpan.metacpan.org/authors/id/B/BR/BRIANDFOY

--- a/python/py-calver/Portfile
+++ b/python/py-calver/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           python 1.0
 
 name                py-calver
-version             2025.4.2
+version             2025.4.17
 revision            0
 
 categories-append   science
@@ -19,9 +19,9 @@ homepage            https://github.com/di/calver
 supported_archs     noarch
 platforms           {darwin any}
 
-checksums           rmd160  a4a933d800ea961e020e75fb14ab89b0e178a978 \
-                    sha256  f854bb865a070da3d45f989f812b2fb6847a10c2d5a7490490ec16832617a463 \
-                    size    7719
+checksums           rmd160  aa4b89f60a0bcd30f129fd5136a9b2bf5f6d7c0c \
+                    sha256  460702737d620f5c3d4175450485180a1b7f7a422c5db0e6af3e655c7395ec7e \
+                    size    8082
 
 python.versions     37 38 39 310 311 312 313
 

--- a/python/py-gdal/Portfile
+++ b/python/py-gdal/Portfile
@@ -6,7 +6,7 @@ PortGroup           select 1.0
 
 name                py-gdal
 # keep version in sync with gdal; rebuilt after gdal update
-version             3.10.2
+version             3.10.3
 revision            0
 
 categories-append   gis
@@ -19,9 +19,9 @@ long_description    This Python package and extensions are a number of tools for
 
 homepage            https://www.gdal.org
 
-checksums           rmd160  3b5059a9441c8e81a6b3119543ffb3d486790ead \
-                    sha256  c0cffa8ce9f9c0fa287fcc20b8271c519ca054958420e5880be8bedb432753f4 \
-                    size    838054
+checksums           rmd160  f3cb6bbac686b6802b39e8b8c98c17b25311d994 \
+                    sha256  b5550650daeeae8e41091581d9aea7d75a9f15b0ebbeb8c96e37458fa02264cd \
+                    size    838170
 
 python.versions     39 310 311 312 313
 

--- a/science/gildas/Portfile
+++ b/science/gildas/Portfile
@@ -5,7 +5,7 @@ PortGroup           compilers 1.0
 PortGroup           active_variants 1.1
 
 name                gildas
-version             202504a
+version             202504b
 set my_version      [string tolower [clock format [clock scan 2000-[string range ${version} 4 5]-10] -format %b]][string range ${version} 2 3][string range ${version} 6 end]
 
 supported_archs     arm64 x86_64
@@ -31,9 +31,9 @@ master_sites        https://www.iram.fr/~gildas/dist/ \
 distname            ${name}-src-${my_version}
 use_xz              yes
 
-checksums           rmd160  5c75d8a1de511233e32de7747437c4b60823f973 \
-                    sha256  100fc3c6d4194b577c07f36e3ce67cd1de4e9d992ba52152a756f5cc6e7e4f82 \
-                    size    48278408
+checksums           rmd160  13b34c4293507b68b2933b059c5050f5954fd7c7 \
+                    sha256  326079d2d42c4878ef3d648cc38f3938e5d420bf136d2924dc90b880d9863fd1 \
+                    size    48260260
 
 patch.pre_args-replace  -p0 -p1
 patchfiles          patch-admin-Makefile.def.diff \

--- a/sysutils/mise/Portfile
+++ b/sysutils/mise/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           github  1.0
 PortGroup           cargo   1.0
 
-github.setup        jdx mise 2025.4.3 v
+github.setup        jdx mise 2025.4.5 v
 github.tarball_from archive
 revision            0
 
@@ -25,9 +25,9 @@ maintainers         {outlook.com:gjq.uoiai @MisLink} \
                     openmaintainer
 
 checksums           ${distname}${extract.suffix} \
-                    rmd160  dd3a6de8e3fb9da4ceba6b74193f7364250378f2 \
-                    sha256  23ebc24548f74bce291e2145564221ab3727593b1526ff55d157a23a87864d0f \
-                    size    4153332
+                    rmd160  1eb3ec9ae08b61d03b28c71596a9f76df418cc6f \
+                    sha256  83a355d3d86382308b7bf1b911f7513804eaaeac52ba69a73e371aaaef6952cf \
+                    size    4154559
 
 patchfiles          patch-src_cli_self_update.diff
 
@@ -396,7 +396,7 @@ cargo.crates \
     lazy-regex                       3.4.1  60c7310b93682b36b98fa7ea4de998d3463ccbebd94d935d6b48ba5b6ffa7126 \
     lazy-regex-proc_macros           3.4.1  4ba01db5ef81e17eb10a5e0f2109d1b3a3e29bac3070fdbd7d156bf7dbd206a1 \
     lazy_static                      1.5.0  bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe \
-    libc                           0.2.171  c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6 \
+    libc                           0.2.172  d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa \
     libm                            0.2.11  8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa \
     libredox                         0.1.3  c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d \
     linked-hash-map                  0.5.6  0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f \
@@ -496,7 +496,7 @@ cargo.crates \
     proc-macro-error-attr            1.0.4  a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869 \
     proc-macro-error-attr2           2.0.0  96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5 \
     proc-macro-error2                2.0.1  11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802 \
-    proc-macro2                     1.0.94  a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84 \
+    proc-macro2                     1.0.95  02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778 \
     prodash                         29.0.2  f04bb108f648884c23b98a0e940ebc2c93c0c3b89f04dbaf7eb8256ce617d1bc \
     quick-xml                       0.37.4  a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369 \
     quinn                           0.11.7  c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012 \
@@ -505,7 +505,7 @@ cargo.crates \
     quote                           1.0.40  1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d \
     r-efi                            5.2.0  74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5 \
     rand                             0.8.5  34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404 \
-    rand                             0.9.0  3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94 \
+    rand                             0.9.1  9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97 \
     rand_chacha                      0.3.1  e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88 \
     rand_chacha                      0.9.0  d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb \
     rand_core                        0.6.4  ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c \

--- a/textproc/heirloom-doctools/Portfile
+++ b/textproc/heirloom-doctools/Portfile
@@ -2,6 +2,7 @@
 
 PortSystem          1.0
 PortGroup           github 1.0
+PortGroup           makefile 1.0
 
 github.setup        n-t-roff heirloom-doctools 191015
 # Change github.tarball_from to 'releases' or 'archive' next update
@@ -25,7 +26,8 @@ checksums           rmd160  d10ce4f4c5f8d636e5e28c6ade8619fdfe1d5f5a \
 
 conflicts           groff
 
-configure.pre_args  && env | grep -E '^(CC?|CPP|CXX|LD)(FLAGS)?=' >> cfg.mk
+# error: tool 'bison' requires Xcode
+use_xcode           yes
 
 build.target
 build.args          ROOT=${destroot} \
@@ -42,4 +44,4 @@ build.args          ROOT=${destroot} \
 
 use_parallel_build  no
 
-destroot.args       ${build.args}
+destroot.args       {*}${build.args}

--- a/textproc/xan/Portfile
+++ b/textproc/xan/Portfile
@@ -4,7 +4,7 @@ PortSystem          1.0
 PortGroup           cargo   1.0
 PortGroup           github  1.0
 
-github.setup        medialab xan 0.49.0
+github.setup        medialab xan 0.49.1
 github.tarball_from archive
 revision            0
 
@@ -41,9 +41,9 @@ maintainers         {gmail.com:herby.gillot @herbygillot} \
                     openmaintainer
 
 checksums-append    ${distname}${extract.suffix} \
-                    rmd160  4b59cd1eb8ab8232db974403cf35e1dfce4c2008 \
-                    sha256  46e73d305a9982eb219e45399590be02a24a03d97e91aa4adc080303dcaff87d \
-                    size    5676625
+                    rmd160  31dbcc1a5e7ea31c28cf12998172738f81091a4f \
+                    sha256  a17cd8cc0463548541d2aadb0f2f559ec9d6cb3e58463ee32e4e50e09677a8a7 \
+                    size    5676596
 
 destroot {
     xinstall -m 0755 \
@@ -293,7 +293,7 @@ cargo.crates \
     regex-syntax                     0.8.5  2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c \
     rmp                             0.8.14  228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4 \
     rmp-serde                        1.3.0  52e599a477cf9840e92f2cde9a7189e67b42c57532749bf90aea6ec10facd4db \
-    rust_xlsxwriter                 0.84.2  471ad60b86a26bae9b541a7c3561174c22f474202e653b78f47549939d6b93fa \
+    rust_xlsxwriter                 0.84.1  a844d972bb19f538ccf0f26383b70d8aa14ff97854f0558d1cd822d611e7da5f \
     rustc_version                    0.2.3  138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a \
     rustix                           1.0.5  d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf \
     rustversion                     1.0.20  eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2 \
@@ -398,7 +398,7 @@ cargo.crates \
     zeroize_derive                   1.4.2  ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69 \
     zerovec                         0.10.4  aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079 \
     zerovec-derive                  0.10.3  6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6 \
-    zip                              2.5.0  27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88 \
+    zip                              2.4.1  938cc23ac49778ac8340e366ddc422b2227ea176edb447e23fc0627608dddadd \
     zopfli                           0.8.1  e5019f391bac5cf252e93bbcc53d039ffd62c7bfb7c150414d61369afe57e946 \
     zstd                            0.13.3  e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a \
     zstd-safe                        7.2.4  8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d \


### PR DESCRIPTION
Update ddev port to version 1.24.4.\n\nRelease notes: https://github.com/ddev/ddev/releases/tag/v1.24.4